### PR TITLE
Fixed faulty python function parameter parsing

### DIFF
--- a/src/llmtool/dfbscan/intra_dataflow_analyzer.py
+++ b/src/llmtool/dfbscan/intra_dataflow_analyzer.py
@@ -1,7 +1,7 @@
 from os import path
 import json
 import time
-from typing import List, Set, Optional, Dict
+from typing import List, Set, Optional, Dict, Any
 from llmtool.LLM_utils import *
 from llmtool.LLM_tool import *
 from memory.syntactic.function import *
@@ -138,7 +138,7 @@ class IntraDataFlowAnalyzer(LLMTool):
             r"Line:\s*([^;]+);"
         )
 
-        current_path = None
+        current_path : dict[str, Any] | None = None
         for line in response.splitlines():
             line = line.strip().lstrip("-").strip()
             if not line:

--- a/src/llmtool/dfbscan/intra_dataflow_analyzer.py
+++ b/src/llmtool/dfbscan/intra_dataflow_analyzer.py
@@ -138,7 +138,7 @@ class IntraDataFlowAnalyzer(LLMTool):
             r"Line:\s*([^;]+);"
         )
 
-        current_path : dict[str, Any] | None = None
+        current_path: dict[str, Any] | None = None
         for line in response.splitlines():
             line = line.strip().lstrip("-").strip()
             if not line:

--- a/src/tstool/analyzer/Python_TS_analyzer.py
+++ b/src/tstool/analyzer/Python_TS_analyzer.py
@@ -159,6 +159,10 @@ class Python_TSAnalyzer(TSAnalyzer):
             parameter_name = ""
             for sub_node in parameter_node.children:
                 for sub_sub_node in find_nodes_by_type(sub_node, "identifier"):
+                    if sub_sub_node.parent and sub_sub_node.parent.type == "type":
+                        # Disregard type annotations
+                        continue
+
                     parameter_name = file_content[
                         sub_sub_node.start_byte : sub_sub_node.end_byte
                     ]


### PR DESCRIPTION
In Python_TS_Analyzer.py, the function get_parameters_in_single_function() only checks nodes with the type "identifier" when finding parameters. Since identifier nodes are also present within type annotations, this fault would cause type annotations to be mistakenly interpreted as a separate parameter.

The fix added a new condition to check if the parent of an identifier node (if it exist) has type "type", If so, the identifier node would be ignored.